### PR TITLE
🔧 Actualizar GitHub Actions a versiones más recientes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Setup Pages
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v4
       
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v2
+      uses: actions/upload-pages-artifact@v3
       with:
         path: '.'
         
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4
 
 permissions:
   contents: read


### PR DESCRIPTION
- actions/checkout: v3 → v4
- actions/configure-pages: v3 → v4
- actions/upload-pages-artifact: v2 → v3
- actions/deploy-pages: v2 → v4

Soluciona el error de deprecation de v3 artifact actions