### PR TITLE
🔧 Fix GitHub Pages deployment - Add required environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    
     steps:
     - uses: actions/checkout@v4
     


### PR DESCRIPTION
Soluciona el error de deployment de GitHub Pages añadiendo el environment requerido por v4.

Cambios:
- ✅ Añadir `environment: github-pages` al job
- ✅ Incluir URL output para el sitio desplegado